### PR TITLE
Use locally scoped jQuery alias instead of jQuery

### DIFF
--- a/src/jquery.requestAnimationFrame.js
+++ b/src/jquery.requestAnimationFrame.js
@@ -31,7 +31,7 @@ for(; lastTime < vendors.length && !requestAnimationFrame; lastTime++) {
 function raf() {
 	if ( animating ) {
 		requestAnimationFrame( raf );
-		jQuery.fx.tick();
+		$.fx.tick();
 	}
 }
 
@@ -39,14 +39,14 @@ if ( requestAnimationFrame ) {
 	// use rAF
 	window.requestAnimationFrame = requestAnimationFrame;
 	window.cancelAnimationFrame = cancelAnimationFrame;
-	jQuery.fx.timer = function( timer ) {
-		if ( timer() && jQuery.timers.push( timer ) && !animating ) {
+	$.fx.timer = function( timer ) {
+		if ( timer() && $.timers.push( timer ) && !animating ) {
 			animating = true;
 			raf();
 		}
 	};
 
-	jQuery.fx.stop = function() {
+	$.fx.stop = function() {
 		animating = false;
 	};
 } else {


### PR DESCRIPTION
By using the local `$` var instead of `jQuery` inside the module, this script can be included on a page and `jQuery.noConflict(true)` can be called after it without issue.

Makes for an easy solution for people who want to have a clean global namespace or who need to manage a situation with multiple jQuery libraries (or a similarly messy situation).
