### PR TITLE
Drop unneeded polyfill & Firefox prefix.

### DIFF
--- a/dist/jquery.requestAnimationFrame.js
+++ b/dist/jquery.requestAnimationFrame.js
@@ -1,16 +1,16 @@
-/*! jQuery requestAnimationFrame - v0.1.3pre - 2015-04-27
+/*! jQuery requestAnimationFrame - v0.1.3pre - 2016-02-03
 * https://github.com/gnarf37/jquery-requestAnimationFrame
-* Copyright (c) 2015 Corey Frang; Licensed MIT */
+* Copyright (c) 2016 Corey Frang; Licensed MIT */
 
 // UMD factory https://github.com/umdjs/umd/blob/master/jqueryPlugin.js
 (function (factory) {
-  if (typeof define === 'function' && define.amd) {
+	if (typeof define === 'function' && define.amd) {
 		// AMD. Register as an anonymous module.
 		define(['jquery'], factory);
-  } else {
+	} else {
 		// Browser globals
 		factory(jQuery);
-  }
+	}
 }(function (jQuery) {
 
 // requestAnimationFrame polyfill adapted from Erik Möller
@@ -19,30 +19,16 @@
 // http://my.opera.com/emoller/blog/2011/12/20/requestanimationframe-for-smart-er-animating
 
 
-var animating,
-	lastTime = 0,
-	vendors = ['webkit', 'moz'],
-	requestAnimationFrame = window.requestAnimationFrame,
-	cancelAnimationFrame = window.cancelAnimationFrame;
-
-for(; lastTime < vendors.length && !requestAnimationFrame; lastTime++) {
-	requestAnimationFrame = window[ vendors[lastTime] + "RequestAnimationFrame" ];
-	cancelAnimationFrame = cancelAnimationFrame ||
-		window[ vendors[lastTime] + "CancelAnimationFrame" ] || 
-		window[ vendors[lastTime] + "CancelRequestAnimationFrame" ];
-}
+var animating;
 
 function raf() {
 	if ( animating ) {
-		requestAnimationFrame( raf );
+		window.requestAnimationFrame( raf );
 		jQuery.fx.tick();
 	}
 }
 
-if ( requestAnimationFrame ) {
-	// use rAF
-	window.requestAnimationFrame = requestAnimationFrame;
-	window.cancelAnimationFrame = cancelAnimationFrame;
+if ( window.requestAnimationFrame ) {
 	jQuery.fx.timer = function( timer ) {
 		if ( timer() && jQuery.timers.push( timer ) && !animating ) {
 			animating = true;
@@ -53,22 +39,6 @@ if ( requestAnimationFrame ) {
 	jQuery.fx.stop = function() {
 		animating = false;
 	};
-} else {
-	// polyfill
-	window.requestAnimationFrame = function( callback, element ) {
-		var currTime = new Date().getTime(),
-			timeToCall = Math.max( 0, 16 - ( currTime - lastTime ) ),
-			id = window.setTimeout( function() {
-				callback( currTime + timeToCall );
-			}, timeToCall );
-		lastTime = currTime + timeToCall;
-		return id;
-	};
-
-	window.cancelAnimationFrame = function(id) {
-		clearTimeout(id);
-	};
-    
 }
 
 }));

--- a/dist/jquery.requestAnimationFrame.min.js
+++ b/dist/jquery.requestAnimationFrame.min.js
@@ -1,4 +1,4 @@
-/*! jQuery requestAnimationFrame - v0.1.3pre - 2015-04-27
+/*! jQuery requestAnimationFrame - v0.1.3pre - 2016-02-03
 * https://github.com/gnarf37/jquery-requestAnimationFrame
-* Copyright (c) 2015 Corey Frang; Licensed MIT */
-(function(e){typeof define=="function"&&define.amd?define(["jquery"],e):e(jQuery)})(function(e){function o(){t&&(i(o),e.fx.tick())}var t,n=0,r=["webkit","moz"],i=window.requestAnimationFrame,s=window.cancelAnimationFrame;for(;n<r.length&&!i;n++)i=window[r[n]+"RequestAnimationFrame"],s=s||window[r[n]+"CancelAnimationFrame"]||window[r[n]+"CancelRequestAnimationFrame"];i?(window.requestAnimationFrame=i,window.cancelAnimationFrame=s,e.fx.timer=function(n){n()&&e.timers.push(n)&&!t&&(t=!0,o())},e.fx.stop=function(){t=!1}):(window.requestAnimationFrame=function(e,t){var r=(new Date).getTime(),i=Math.max(0,16-(r-n)),s=window.setTimeout(function(){e(r+i)},i);return n=r+i,s},window.cancelAnimationFrame=function(e){clearTimeout(e)})});
+* Copyright (c) 2016 Corey Frang; Licensed MIT */
+(function(e){typeof define=="function"&&define.amd?define(["jquery"],e):e(jQuery)})(function(e){function n(){t&&(window.requestAnimationFrame(n),e.fx.tick())}var t;window.requestAnimationFrame&&(e.fx.timer=function(r){r()&&e.timers.push(r)&&!t&&(t=!0,n())},e.fx.stop=function(){t=!1})});

--- a/src/jquery.requestAnimationFrame.js
+++ b/src/jquery.requestAnimationFrame.js
@@ -23,30 +23,16 @@
 // http://my.opera.com/emoller/blog/2011/12/20/requestanimationframe-for-smart-er-animating
 
 
-var animating,
-	lastTime = 0,
-	vendors = ['webkit', 'moz'],
-	requestAnimationFrame = window.requestAnimationFrame,
-	cancelAnimationFrame = window.cancelAnimationFrame;
-
-for(; lastTime < vendors.length && !requestAnimationFrame; lastTime++) {
-	requestAnimationFrame = window[ vendors[lastTime] + "RequestAnimationFrame" ];
-	cancelAnimationFrame = cancelAnimationFrame ||
-		window[ vendors[lastTime] + "CancelAnimationFrame" ] ||
-		window[ vendors[lastTime] + "CancelRequestAnimationFrame" ];
-}
+var animating;
 
 function raf() {
 	if ( animating ) {
-		requestAnimationFrame( raf );
+		window.requestAnimationFrame( raf );
 		jQuery.fx.tick();
 	}
 }
 
-if ( requestAnimationFrame ) {
-	// use rAF
-	window.requestAnimationFrame = requestAnimationFrame;
-	window.cancelAnimationFrame = cancelAnimationFrame;
+if ( window.requestAnimationFrame ) {
 	jQuery.fx.timer = function( timer ) {
 		if ( timer() && jQuery.timers.push( timer ) && !animating ) {
 			animating = true;
@@ -57,22 +43,6 @@ if ( requestAnimationFrame ) {
 	jQuery.fx.stop = function() {
 		animating = false;
 	};
-} else {
-	// polyfill
-	window.requestAnimationFrame = function( callback, element ) {
-		var currTime = new Date().getTime(),
-			timeToCall = Math.max( 0, 16 - ( currTime - lastTime ) ),
-			id = window.setTimeout( function() {
-				callback( currTime + timeToCall );
-			}, timeToCall );
-		lastTime = currTime + timeToCall;
-		return id;
-	};
-
-	window.cancelAnimationFrame = function(id) {
-		clearTimeout(id);
-	};
-
 }
 
 }));


### PR DESCRIPTION
1) Firefox prefix hasn't been needed since v23 (we're on 26 now, in 2 days on 27; the last ESR is 24, ESR 17 is no longer supported)

2) The polyfill for rAF wasn't used at all in the plugin and was contributing significantly to the file size. Similarly, `cancelAnimationFrame` was feature-detected but then not needed at all. I removed the polyfill & other unneeded parts, shaving off 158 bytes of 428 gzipped.